### PR TITLE
v0.12 preparation: Fix metadata usage to be canonical

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,8 +61,8 @@ resource "oci_core_volume" "this" {
   count               = "${var.instance_count * length(var.block_storage_sizes_in_gbs)}"
   availability_domain = "${oci_core_instance.this.*.availability_domain[count.index % var.instance_count]}"
   compartment_id      = "${var.compartment_ocid}"
-  display_name        = "${oci_core_instance.this.*.display_name[count.index % var.instance_count]}_volume${count.index / var.instance_count}"
-  size_in_gbs         = "${element(var.block_storage_sizes_in_gbs, count.index / var.instance_count)}"
+  display_name        = "${oci_core_instance.this.*.display_name[count.index % var.instance_count]}_volume${floor(count.index / var.instance_count)}"
+  size_in_gbs         = "${element(var.block_storage_sizes_in_gbs, floor(count.index / var.instance_count))}"
 }
 
 ####################

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "oci_core_instance" "this" {
     subnet_id              = "${data.oci_core_subnet.this.*.id[count.index % length(data.oci_core_subnet.this.*.id)]}"
   }
 
-  metadata {
+  metadata = {
     ssh_authorized_keys = "${file("${var.ssh_authorized_keys}")}"
     user_data           = "${var.user_data}"
   }


### PR DESCRIPTION
Fields such as "metadata" which are map types should be assigned with "=" operators. Without this change, this module will result in syntax errors in v0.12.