### PR TITLE
Create contributing guide document.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,24 @@
+## 2.0.1 - 2021-01-22
+
+### Added
+
+* CONTRIBUTING.md - contributor's guide
+
+### Changed
+
+* Add link to CONTRIBUTING.md in README.md
+* Bump copyright year to 2021 in README.md
+
 ## 2.0.0 - 2018-12-04
 
 ### Changed
+
 - Updated Hostname label for multiple compute instances
 - Updated Volume display name
 - Changes variable assign_public_ip default from true to false 
 
 ### Added
+
 * Support for multiple subnets
 * Support for paravirtualized attachments 
 * Support for private IP list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.1 - 2021-01-22
+## 2.0.2 - 2021-01-22
 
 ### Added
 
@@ -8,6 +8,14 @@
 
 * Add link to CONTRIBUTING.md in README.md
 * Bump copyright year to 2021 in README.md
+
+
+## 2.0.1 - 2019-05-08
+
+### Changed
+
+* v0.12 preparation: Fix metadata usage to be canonical
+
 
 ## 2.0.0 - 2018-12-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,14 @@ Only pull requests from committers that can be verified as having signed the OCA
 
 1. Create a branch in your own fork to implement the changes. We recommend using the issue number as part of your branch name, e.g.: `1234-fixes`
 
-1. Ensure that any documentation is updated with the changes that are required by your fix.
+1. Ensure that any documentation is updated with the changes that are required by your fix
 
-1. Ensure that any samples are updated if the base image has been changed.
+1. Update README.md when necessary
 
-1. Submit the pull request. **Do not leave the pull request description blank**. Explain exactly what your changes are meant to do and provide simple steps on how to validate your changes. Ensure that you reference the issue you created as well. We will assign the pull request to 2-3 people for review before it is merged.
+1. Ensure that any samples are updated if the base image has been changed
+
+1. Update CHANGELOG.md - add information about the changes that are done in this pull request, increment the version
+
+1. Tag your branch with the new version
+
+1. Submit the pull request. **Do not leave the pull request description blank**. Explain exactly what your changes are meant to do and provide simple steps on how to validate your changes. Ensure that you reference the issue you created as well adding `#1234` to the description. We will assign the pull request to 2-3 people for review before it is merged.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# CONTRIBUTING
+
+Oracle welcomes contributions to this repository from anyone.
+
+If you want to submit a pull request to fix a bug or enhance an existing feature, please first open an issue and link to that issue when you submit your pull request.
+
+If you have any questions about a possible submission, feel free to open an issue too.
+
+## Contributing to the terraform-oci-compute-instance repository
+
+Pull requests can be made under The Oracle Contributor Agreement(OCA).
+
+For pull requests to be accepted, the bottom of your commit message must have the following line using your name and e-mail address as it appears in the OCA Signatories list.
+
+`Signed-off-by: Your Name <you@example.org>`
+
+This can be automatically added to pull requests by committing with:
+
+`git commit --signoff`
+
+or by turning on the "Always Sign Off" flag in your IDE's preferences.
+
+Only pull requests from committers that can be verified as having signed the OCA can be accepted.
+
+## Pull request process
+
+1. Fork this repository
+
+1. Create a branch in your own fork to implement the changes. We recommend using the issue number as part of your branch name, e.g.: `1234-fixes`
+
+1. Ensure that any documentation is updated with the changes that are required by your fix.
+
+1. Ensure that any samples are updated if the base image has been changed.
+
+1. Submit the pull request. **Do not leave the pull request description blank**. Explain exactly what your changes are meant to do and provide simple steps on how to validate your changes. Ensure that you reference the issue you created as well. We will assign the pull request to 2-3 people for review before it is merged.

--- a/README.md
+++ b/README.md
@@ -174,11 +174,13 @@ echo "$uuid ${var.volume_mount_directory} ext4 defaults,noatime,_netdev,nofail  
 
 ## Contributing
 
-This project is open source. Oracle appreciates any contributions that are made by the open source community.
+This project is open source. Oracle appreciates any contributions that are made by the open source community. 
+
+Learn how to [contribute](CONTRIBUTING.md)).
 
 ## License
 
-Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
 
 Licensed under the Universal Permissive License 1.0 or Apache License 2.0.
 


### PR DESCRIPTION
The contrib guide is taken from https://github.com/oracle-terraform-modules/terraform-oci-oke.
Also bumping copyright to 2021 in README.md and linking the CONTRIBUTING.md document there.

Signed-off-by: Alexey Dolganov <alexey.dolganov@oracle.com>