### PR TITLE
add Flex instance shape support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.txt    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=4
+*.md    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=4
+*.tf    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v3.4.0 # Get the latest from: https://github.com/pre-commit/pre-commit-hooks/releases
+  hooks:
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+- repo: https://github.com/gruntwork-io/pre-commit
+  rev: v0.1.12 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+  hooks:
+    - id: terraform-validate
+    # - id: terraform-fmt #* this version of tf-fmt detect problem and fails. You have to run tf fmt yourself
+- repo: https://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.45.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
+  hooks:
+    - id: terraform_docs
+    - id: terraform_fmt #* this version of tf-fmt actually runs fmt and fix files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Given a version number MAJOR.MINOR.PATCH:
 
 ## [UNRELEASED]
 
+Features:
+
+- add Flex instance shape support
+
+Repo maintenance:
+
+- add .gitattributes for consistent line ending and tab
+- add pre-commit configuration file
+
 ## 2.0.4 - 2021-02-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ Given a version number MAJOR.MINOR.PATCH:
 
 ## [UNRELEASED]
 
-Features:
+Added:
 
-- add Flex instance shape support
+- support Flex instance shape
+- new output : instances_summary
+
+Fixed:
+
+- Outputs produces unnecessarily multidimensional objects (Issue #31)
 
 Repo maintenance:
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ module "instance" {
 | hostname\_label | The hostname for the VNIC's primary private IP. | `string` | `""` | no |
 | instance\_count | Number of instances to launch. | `number` | `1` | no |
 | instance\_display\_name | (Optional) (Updatable) A user-friendly name for the instance. Does not have to be unique, and it's changeable. | `string` | `""` | no |
+| instance\_flex\_memory\_in\_gbs | (Optional) (Updatable) The total amount of memory available to the instance, in gigabytes. | `number` | `null` | no |
+| instance\_flex\_ocpus | (Optional) (Updatable) The total number of OCPUs available to the instance. | `number` | `null` | no |
 | instance\_timeout | Timeout setting for creating instance. | `string` | `"25m"` | no |
 | ipxe\_script | (Optional) The iPXE script which to continue the boot process on the instance. | `string` | `null` | no |
 | preserve\_boot\_volume | Specifies whether to delete or preserve the boot volume when terminating an instance. | `bool` | `false` | no |
@@ -82,6 +84,7 @@ module "instance" {
 | instance\_id | ocid of created instances. |
 | instance\_password | Passwords to login to Windows instance. |
 | instance\_username | Usernames to login to Windows instance. |
+| instances\_summary | Private and Public IPs for each instance. |
 | private\_ip | Private IPs of created instances. |
 | public\_ip | Public IPs of created instances. |
 

--- a/examples/instance_default/README.md
+++ b/examples/instance_default/README.md
@@ -1,3 +1,4 @@
+<!-- TO BE EDITED -->
 ## Create Compute Instance
 This example creates a compute instance and a set of block volumes.
 
@@ -30,8 +31,8 @@ block_storage_sizes_in_gbs = [60, 70]
 
 Then apply the example using the following commands:
 
-```
-$ terraform init
-$ terraform plan
-$ terraform apply
+```shell
+> terraform init
+> terraform plan
+> terraform apply
 ```

--- a/examples/instance_default/instance_default.tf
+++ b/examples/instance_default/instance_default.tf
@@ -45,7 +45,8 @@ variable "block_storage_sizes_in_gbs" {
 }
 
 variable "shape" {
-  type = string
+  type    = string
+  default = null
 }
 
 variable "assign_public_ip" {
@@ -64,16 +65,67 @@ provider "oci" {
   region           = var.region
 }
 
-module "instance" {
+# * This module will create a Flex Compute Instance, using default values: 1 OCPU, 16 GB memory.
+module "instance_flex" {
   source                     = "../../"
-  instance_count             = var.instance_count
+  instance_count             = 1
+  shape                      = "VM.Standard.E3.Flex"
   ad_number                  = 1
   compartment_ocid           = var.compartment_ocid
-  instance_display_name      = var.instance_display_name
+  instance_display_name      = "instance_flex"
   source_ocid                = var.source_ocid
   subnet_ocids               = var.subnet_ocids
   ssh_authorized_keys        = var.ssh_authorized_keys
   block_storage_sizes_in_gbs = var.block_storage_sizes_in_gbs
-  shape                      = var.shape
   assign_public_ip           = var.assign_public_ip
+}
+
+# * This module will create a Flex Compute Instance, using values provided by the module: 1 OCPU, 1 GB memory.
+module "instance_flex_custom" {
+  source                      = "../../"
+  instance_count              = 2
+  shape                       = "VM.Standard.E3.Flex"
+  instance_flex_memory_in_gbs = 1
+  instance_flex_ocpus         = 1
+  ad_number                   = 1
+  compartment_ocid            = var.compartment_ocid
+  instance_display_name       = "instance_flex_custom"
+  source_ocid                 = var.source_ocid
+  subnet_ocids                = var.subnet_ocids
+  ssh_authorized_keys         = var.ssh_authorized_keys
+  block_storage_sizes_in_gbs  = var.block_storage_sizes_in_gbs
+  assign_public_ip            = var.assign_public_ip
+}
+
+# * This module will create a shape-based Compute Instance. OCPU and memory values are defined by the shape.
+module "instance_nonflex" {
+  source                     = "../../"
+  instance_count             = 1
+  shape                      = "VM.Standard2.1"
+  ad_number                  = 2
+  compartment_ocid           = var.compartment_ocid
+  instance_display_name      = "instance_nonflex"
+  source_ocid                = var.source_ocid
+  subnet_ocids               = var.subnet_ocids
+  ssh_authorized_keys        = var.ssh_authorized_keys
+  block_storage_sizes_in_gbs = var.block_storage_sizes_in_gbs
+  assign_public_ip           = var.assign_public_ip
+}
+
+# * This module will create a shape-based Compute instance. OCPU and memory values are defined by the shape.
+# * `instance_flex_memory_in_gbs` and ìnstance_flex_ocpus` values are ignored.
+module "instance_nonflex_custom" {
+  source                      = "../../"
+  instance_count              = 1
+  shape                       = "VM.Standard2.1"
+  instance_flex_memory_in_gbs = 8
+  instance_flex_ocpus         = 1
+  ad_number                   = 2
+  compartment_ocid            = var.compartment_ocid
+  instance_display_name       = "instance_nonflex_custom"
+  source_ocid                 = var.source_ocid
+  subnet_ocids                = var.subnet_ocids
+  ssh_authorized_keys         = var.ssh_authorized_keys
+  block_storage_sizes_in_gbs  = var.block_storage_sizes_in_gbs
+  assign_public_ip            = var.assign_public_ip
 }

--- a/examples/instance_default/outputs.tf
+++ b/examples/instance_default/outputs.tf
@@ -1,27 +1,21 @@
 // Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
-output "instance_id" {
+output "instance_flex" {
   description = "ocid of created instances. "
-  value       = module.instance.instance_id
+  value       = module.instance_flex.instances_summary
 }
 
-output "private_ip" {
-  description = "Private IPs of created instances. "
-  value       = module.instance.private_ip
+output "instance_flex_custom" {
+  description = "ocid of created instances. "
+  value       = module.instance_flex_custom.instances_summary
 }
 
-output "public_ip" {
-  description = "Public IPs of created instances. "
-  value       = module.instance.public_ip
+output "instance_nonflex" {
+  description = "ocid of created instances. "
+  value       = module.instance_nonflex.instances_summary
 }
 
-output "instance_username" {
-  description = "Usernames to login to Windows instance. "
-  value       = module.instance.instance_username
-}
-
-output "instance_password" {
-  description = "Passwords to login to Windows instance. "
-  sensitive   = true
-  value       = module.instance.instance_password
+output "instance_nonflex_custom" {
+  description = "ocid of created instances. "
+  value       = module.instance_nonflex_custom.instances_summary
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,28 +1,43 @@
 // Copyright (c) 2018, 2021, Oracle and/or its affiliates.
 
+locals {
+  instances_details = [
+    // display name, Primary VNIC Public/Private IP for each instance
+    for i in oci_core_instance.this : <<EOT
+    ${~i.display_name~}
+    Primary-PublicIP: %{if i.public_ip != ""}${i.public_ip~}%{else}N/A%{endif~}
+    Primary-PrivateIP: ${i.private_ip~}
+    EOT
+  ]
+}
+
+output "instances_summary" {
+  description = "Private and Public IPs for each instance."
+  value       = local.instances_details
+}
+
 output "instance_id" {
   description = "ocid of created instances. "
-  value       = [oci_core_instance.this.*.id]
+  value       = oci_core_instance.this.*.id
 }
 
 output "private_ip" {
   description = "Private IPs of created instances. "
-  value       = [oci_core_instance.this.*.private_ip]
+  value       = oci_core_instance.this.*.private_ip
 }
 
 output "public_ip" {
   description = "Public IPs of created instances. "
-  value       = [oci_core_instance.this.*.public_ip]
+  value       = oci_core_instance.this.*.public_ip
 }
 
 output "instance_username" {
   description = "Usernames to login to Windows instance. "
-  value       = [data.oci_core_instance_credentials.this.*.username]
+  value       = data.oci_core_instance_credentials.this.*.username
 }
 
 output "instance_password" {
   description = "Passwords to login to Windows instance. "
   sensitive   = true
-  value       = [data.oci_core_instance_credentials.this.*.password]
+  value       = data.oci_core_instance_credentials.this.*.password
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -54,6 +54,18 @@ variable "shape" {
   default     = "VM.Standard2.1"
 }
 
+variable "instance_flex_memory_in_gbs" {
+  type        = number
+  description = "(Optional) (Updatable) The total amount of memory available to the instance, in gigabytes."
+  default     = null
+}
+
+variable "instance_flex_ocpus" {
+  type        = number
+  description = "(Optional) (Updatable) The total number of OCPUs available to the instance."
+  default     = null
+}
+
 variable "assign_public_ip" {
   description = "Whether the VNIC should be assigned a public IP address."
   type        = bool


### PR DESCRIPTION
Ideally, same module should allow for provisioning both flex and non flex (shape-based) instances.
Flex instance requires an additionnal shape_config block with specific parameters. See OCI provider documentation for details.

The solution needs for behave correctly with the fallback options.

Fix #42, #31