### PR TITLE
add reserved public ip

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -26,8 +26,8 @@ Given a version number MAJOR.MINOR.PATCH:
 * Add support for freeform and defined tags for instances, vnics and block volumes (Fix #10, #11, #12, #13, #18, #20)
 * Add "module watermark" freeform tags: module defined and user defined freeform tags are merged on the final resource
 * Add support to provide the `ssh_authorized_keys` argument as a string or as a file (Fix #67 #70)
-* Provision instances with reserved Public IP
-* [ ] Define a backup policy for boot volume and additional block volumes
+* Add support for reserved Public IP on instance first VNIC (fix #55)
+* [ ] Define a backup policy for boot volume and additional block volumes (fix #64)
 * Add new outputs for each provisioned resources: "all_attributes" outputs have full provider coverage and are auto-updating.
 
 === Documentation

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -19,6 +19,7 @@ Given a version number MAJOR.MINOR.PATCH:
 === Deprecated
 
 * `var.ssh_authorized_keys` is deprecated. Use `var.ssh_public_keys`.
+* `var.assign_public_ip` is deprecated. Use `var.public_ip` with the predefined keywords instead.
 
 === New features
 

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -25,6 +25,9 @@ Given a version number MAJOR.MINOR.PATCH:
 * Add support for freeform and defined tags for instances, vnics and block volumes (Fix #10, #11, #12, #13, #18, #20)
 * Add "module watermark" freeform tags: module defined and user defined freeform tags are merged on the final resource
 * Add support to provide the `ssh_authorized_keys` argument as a string or as a file (Fix #67 #70)
+* Provision instances with reserved Public IP
+* [ ] Define a backup policy for boot volume and additional block volumes
+* Add new outputs for each provisioned resources: "all_attributes" outputs have full provider coverage and are auto-updating.
 
 === Documentation
 
@@ -47,7 +50,6 @@ Given a version number MAJOR.MINOR.PATCH:
 * Outputs produces unnecessarily multidimensional objects (Issue #31)
 * Repo maintenance:
 ** add .gitattributes for consistent line ending and tab
-** add pre-commit configuration file
 
 == 2.0.4 - 2021-02-13
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Oracle Cloud Infrastructure Terraform Module for Compute Instance
 
-This Module provides an easy way to launch compute instances with advanced settings and good practices embedded.
+This module provides an easy way to launch compute instances with advanced settings and good practices embedded.
 
 On top of the compute instance capabilities, this module can also provision and attach additional Block Volumes to the instances.
 
@@ -10,24 +10,20 @@ On top of the compute instance capabilities, this module can also provision and 
 >
 > Oracle recommends that you do not use custom images without these rules unless you understand the security risks. See [Compute Best Practices](https://docs.cloud.oracle.com/iaas/Content/Compute/References/bestpracticescompute.htm#two) for recommendations on how to manage instances.
 
-## Maintainers
-
-This module is maintained by Oracle.
-
 ## Requirements
 
 The diagram below summarizes the required components and their respective versions to use this module.
 
 ![versions](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/blob/main/docs/diagrams/versions.svg?raw=true&sanitize=true)
 
-To enforce versions compatibility of both Terraform and the OCI provider, your root configuration should ideally include this block in `main.tf` for version pinning:
+To enforce versions compatibility of both Terraform and the OCI provider, your root configuration should ideally include this block for version pinning:
 
 ```HCL
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.6"
   required_providers {
     oci = {
-      version = ">= 3.27"
+      version = ">= 4.0.0"
     }
   }
 }
@@ -59,11 +55,11 @@ module "instance" {
 
 ## What's coming next for this module?
 
-The current focus is to get back in close the gap between this module and the provider's capabilities. We started with a complete code base update for [HCL2 syntax compatibility](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/releases/tag/v2.0.2), then adding support for [Regional Subnets](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/releases/tag/v2.0.4) and now [Flexible Shapes](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/pull/49).
+The current focus is to close the gap between this module and the provider's capabilities. We started with a complete codebase update for [HCL2 syntax compatibility](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/releases/tag/v2.0.2), then adding support for [Regional Subnets](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/releases/tag/v2.0.4) and lastly [Flexible Shapes](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/pull/49).
 
 We will continue to push in that direction with the goal of [feature parity with the provider's capabilities](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/projects/4), as well as adding more features and integration points with other OCI services: Block Volume Backups, Secondary VNICs and IPs, etc ...
 
-Compute Instances are also a perfect place to illustrate [module composition principles](https://www.terraform.io/docs/language/modules/develop/composition.html) reusing the other existing official Terraform OCI Modules
+Given the dependency to Network and Storage for Compute Instances,it is a perfect place to illustrate [module composition principles](https://www.terraform.io/docs/language/modules/develop/composition.html) and how to reuse the other official Terraform OCI modules.
 
 ## Configuring iSCSI volume attachments
 
@@ -73,7 +69,8 @@ Compute Instances are also a perfect place to illustrate [module composition pri
 
 ## Contributing
 
-This project is open source. Oracle appreciates any contributions that are made by the open source community: raising issues, improving documentation, fixing bugs, or adding new features.
+This project is open source and maintained by Oracle.  
+Oracle appreciates any contributions that are made by the open source community: raising issues, improving documentation, fixing bugs, or adding new features.
 
 Learn how to [contribute](https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/blob/main/CONTRIBUTING.adoc).
 

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -25,11 +25,14 @@ No modules.
 |===
 |Name |Type
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_instance[oci_core_instance.this] |resource
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_public_ip[oci_core_public_ip.this] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume[oci_core_volume.this] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_attachment[oci_core_volume_attachment.this] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.this] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_private_ips[oci_core_private_ips.this] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_shapes[oci_core_shapes.ad1] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_subnet[oci_core_subnet.this] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_vnic_attachments[oci_core_vnic_attachments.this] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/identity_availability_domains[oci_identity_availability_domains.ad] |data source
 |===
 
@@ -45,7 +48,7 @@ No modules.
 |no
 
 |[[input_assign_public_ip]] <<input_assign_public_ip,assign_public_ip>>
-|Whether the VNIC should be assigned a public IP address.
+|Deprecated: use `var.public_ip` instead. Whether the VNIC should be assigned a public IP address (Always EPHEMERAL).
 |`bool`
 |`false`
 |no
@@ -146,6 +149,18 @@ No modules.
 |`[]`
 |no
 
+|[[input_public_ip]] <<input_public_ip,public_ip>>
+|OCID of the Public IP to attach to primary vnic. Valid values are NONE, RESERVED or EPHEMERAL.
+|`string`
+|`"NONE"`
+|no
+
+|[[input_public_ip_display_name]] <<input_public_ip_display_name,public_ip_display_name>>
+|(Updatable) A user-friendly name. Does not have to be unique, and it's changeable.
+|`string`
+|`null`
+|no
+
 |[[input_resource_platform]] <<input_resource_platform,resource_platform>>
 |Platform to create resources in.
 |`string`
@@ -219,10 +234,16 @@ No modules.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Description
+|[[output_instance_all_attributes]] <<output_instance_all_attributes,instance_all_attributes>> |all attributes of created instance
 |[[output_instance_id]] <<output_instance_id,instance_id>> |ocid of created instances.
 |[[output_instance_password]] <<output_instance_password,instance_password>> |Passwords to login to Windows instance.
 |[[output_instance_username]] <<output_instance_username,instance_username>> |Usernames to login to Windows instance.
 |[[output_instances_summary]] <<output_instances_summary,instances_summary>> |Private and Public IPs for each instance.
 |[[output_private_ip]] <<output_private_ip,private_ip>> |Private IPs of created instances.
+|[[output_private_ips_all_attributes]] <<output_private_ips_all_attributes,private_ips_all_attributes>> |all attributes of created private ips
 |[[output_public_ip]] <<output_public_ip,public_ip>> |Public IPs of created instances.
+|[[output_public_ip_all_attributes]] <<output_public_ip_all_attributes,public_ip_all_attributes>> |all attributes of created public ip
+|[[output_vnic_attachment_all_attributes]] <<output_vnic_attachment_all_attributes,vnic_attachment_all_attributes>> |all attributes of created vnic attachments
+|[[output_volume_all_attributes]] <<output_volume_all_attributes,volume_all_attributes>> |all attributes of created volumes
+|[[output_volume_attachment_all_attributes]] <<output_volume_attachment_all_attributes,volume_attachment_all_attributes>> |all attributes of created volumes attachments
 |===

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -28,7 +28,7 @@ No modules.
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_public_ip[oci_core_public_ip.public_ip] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume[oci_core_volume.volume] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_attachment[oci_core_volume_attachment.volume_attachment] |resource
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.crendential] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.credential] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_private_ips[oci_core_private_ips.private_ips] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_shapes[oci_core_shapes.ad1] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_subnet[oci_core_subnet.instance_subnet] |data source
@@ -150,7 +150,7 @@ No modules.
 |no
 
 |[[input_public_ip]] <<input_public_ip,public_ip>>
-|Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL.
+|Whether to create a Public IP to attach to primary vnic and which lifetime. Valid values are NONE, RESERVED or EPHEMERAL.
 |`string`
 |`"NONE"`
 |no

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -24,15 +24,15 @@ No modules.
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Type
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_instance[oci_core_instance.this] |resource
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_public_ip[oci_core_public_ip.this] |resource
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume[oci_core_volume.this] |resource
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_attachment[oci_core_volume_attachment.this] |resource
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.this] |data source
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_private_ips[oci_core_private_ips.this] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_instance[oci_core_instance.instance] |resource
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_public_ip[oci_core_public_ip.public_ip] |resource
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume[oci_core_volume.volume] |resource
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_attachment[oci_core_volume_attachment.volume_attachment] |resource
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.crendential] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_private_ips[oci_core_private_ips.private_ips] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_shapes[oci_core_shapes.ad1] |data source
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_subnet[oci_core_subnet.this] |data source
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_vnic_attachments[oci_core_vnic_attachments.this] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_subnet[oci_core_subnet.instance_subnet] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_vnic_attachments[oci_core_vnic_attachments.vnic_attachment] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/identity_availability_domains[oci_identity_availability_domains.ad] |data source
 |===
 
@@ -150,7 +150,7 @@ No modules.
 |no
 
 |[[input_public_ip]] <<input_public_ip,public_ip>>
-|OCID of the Public IP to attach to primary vnic. Valid values are NONE, RESERVED or EPHEMERAL.
+|Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL.
 |`string`
 |`"NONE"`
 |no

--- a/examples/instances_fixed_shape/README.md
+++ b/examples/instances_fixed_shape/README.md
@@ -13,7 +13,8 @@ You will need to collect the following information before you start:
 
 1. your OCI provider authentication values
 2. a compartment OCID in which the instances will be created
-3. a subnet OCID to which the instance's primary VNICs will be attached
+3. a source OCID to deploy the instance, usually an image ocid from [OCI Platform Images list]
+4. a subnet OCID to which the instance's primary VNICs will be attached
 
 For detailed instructions, see [docs/prerequisites.adoc]
 
@@ -33,3 +34,5 @@ Then apply the example using the following commands:
 
 [Terraform Variable Definition file]:https://www.terraform.io/docs/language/values/variables.html#variable-definitions-tfvars-files
 [docs/prerequisites.adoc]:https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/blob/main/docs/prerequisites.adoc
+[Provisioning Infrastructure with Terraform]:https://www.terraform.io/docs/cli/run/index.html
+[OCI Platform Images list]:https://docs.oracle.com/en-us/iaas/images/

--- a/examples/instances_fixed_shape/main.tf
+++ b/examples/instances_fixed_shape/main.tf
@@ -1,10 +1,10 @@
 // Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
 terraform {
-  required_version = ">= 0.12" // terraform version below 0.12 is not tested/supported with this module
+  required_version = ">= 0.13" // terraform version below 0.12 is not tested/supported with this module
   required_providers {
     oci = {
-      version = ">= 3.27" // force downloading oci-provider compatible with terraform v0.12
+      version = ">= 4.0.0" // force downloading oci-provider compatible with terraform v0.12
     }
   }
 }

--- a/examples/instances_fixed_shape/main.tf
+++ b/examples/instances_fixed_shape/main.tf
@@ -34,8 +34,8 @@ module "instance_nonflex" {
   # operating system parameters
   ssh_public_keys = var.ssh_public_keys
   # networking parameters
-  assign_public_ip = var.assign_public_ip
-  subnet_ocids     = var.subnet_ocids
+  public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
+  subnet_ocids = var.subnet_ocids
   # storage parameters
   block_storage_sizes_in_gbs = var.block_storage_sizes_in_gbs
 }
@@ -65,8 +65,8 @@ module "instance_nonflex_custom" {
   # operating system parameters
   ssh_public_keys = var.ssh_public_keys
   # networking parameters
-  assign_public_ip = var.assign_public_ip
-  subnet_ocids     = var.subnet_ocids
+  public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
+  subnet_ocids = var.subnet_ocids
   # storage parameters
   block_storage_sizes_in_gbs = [] # no block volume will be created
 }

--- a/examples/instances_fixed_shape/variables.tf
+++ b/examples/instances_fixed_shape/variables.tf
@@ -119,7 +119,7 @@ variable "assign_public_ip" {
 }
 
 variable "public_ip" {
-  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
+  description = "Whether to create a Public IP to attach to primary vnic and which lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
   type        = string
   default     = "NONE"
 }

--- a/examples/instances_fixed_shape/variables.tf
+++ b/examples/instances_fixed_shape/variables.tf
@@ -118,6 +118,12 @@ variable "assign_public_ip" {
   default     = false
 }
 
+variable "public_ip" {
+  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
+  type        = string
+  default     = "NONE"
+}
+
 variable "subnet_ocids" {
   description = "The unique identifiers (OCIDs) of the subnets in which the instance primary VNICs are created."
   type        = list(string)

--- a/examples/instances_flex_shape/main.tf
+++ b/examples/instances_flex_shape/main.tf
@@ -1,10 +1,10 @@
 // Copyright (c) 2018, 2021 Oracle and/or its affiliates.
 
 terraform {
-  required_version = ">= 0.12" // terraform version below 0.12 is not tested/supported with this module
+  required_version = ">= 0.13" // terraform version below 0.12 is not tested/supported with this module
   required_providers {
     oci = {
-      version = ">= 3.27" // force downloading oci-provider compatible with terraform v0.12
+      version = ">= 4.0.0" // force downloading oci-provider compatible with terraform v0.12
     }
   }
 }

--- a/examples/instances_flex_shape/main.tf
+++ b/examples/instances_flex_shape/main.tf
@@ -37,8 +37,8 @@ module "instance_flex" {
   # operating system parameters
   ssh_public_keys = var.ssh_public_keys
   # networking parameters
-  assign_public_ip = var.assign_public_ip
-  subnet_ocids     = var.subnet_ocids
+  public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
+  subnet_ocids = var.subnet_ocids
   # storage parameters
   block_storage_sizes_in_gbs = var.block_storage_sizes_in_gbs
 }
@@ -67,7 +67,7 @@ output "instance_flex" {
 #   # operating system parameters
 #   ssh_public_key = var.ssh_public_key
 #   # networking parameters
-#   assign_public_ip = var.assign_public_ip
+#   public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
 #   subnet_ocids     = var.subnet_ocids
 #   # storage parameters
 #   block_storage_sizes_in_gbs = [] # no block volume will be created

--- a/examples/instances_flex_shape/variables.tf
+++ b/examples/instances_flex_shape/variables.tf
@@ -120,7 +120,7 @@ variable "ssh_public_keys" {
 # networking parameters
 
 variable "public_ip" {
-  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
+  description = "Whether to create a Public IP to attach to primary vnic and which lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
   type        = string
   default     = "NONE"
 }

--- a/examples/instances_flex_shape/variables.tf
+++ b/examples/instances_flex_shape/variables.tf
@@ -119,10 +119,10 @@ variable "ssh_public_keys" {
 
 # networking parameters
 
-variable "assign_public_ip" {
-  description = "Whether the VNIC should be assigned a public IP address."
-  type        = bool
-  default     = false
+variable "public_ip" {
+  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
+  type        = string
+  default     = "NONE"
 }
 
 variable "subnet_ocids" {

--- a/examples/instances_reserved_public_ip/README.md
+++ b/examples/instances_reserved_public_ip/README.md
@@ -4,7 +4,7 @@ This example illustrates how to use this module to creates compute instances wit
 
 One modules will be configured:
 
-- 1 instance (1 OCPU, 1GB RAM) with a reserved public IP attached the primary VNIC.
+- 1 instance (1 OCPU, 1GB RAM) with a reserved public IP associated with the Primary IP of the primary VNIC.
 
 ## Prerequisites
 

--- a/examples/instances_reserved_public_ip/README.md
+++ b/examples/instances_reserved_public_ip/README.md
@@ -1,11 +1,10 @@
 # Creating Compute Instances using Flex shape
 
-This example illustrates how to use this module to creates compute instances using Flex Shape, and optionally provision and attach a block volume to the created instances.
+This example illustrates how to use this module to creates compute instances with a reserved public IP.
 
-Two modules will be configured:
+One modules will be configured:
 
-- the first module will create 1 instance (1 OCPU, 16GB RAM) with 1 Block Volume (50GB) attached to it
-- the second module, if uncommented,  will create 4 instances (1 OCUP, 1GB RAM) with no additional Block Volume
+- 1 instance (1 OCPU, 1GB RAM) with a reserved public IP attached the primary VNIC.
 
 ## Prerequisites
 
@@ -31,6 +30,8 @@ Then apply the example using the following commands:
 > terraform plan
 > terraform apply
 ```
+
+See [Provisioning Infrastructure with Terraform] for more details about Terraform CLI and the available subcommands.
 
 [Terraform Variable Definition file]:https://www.terraform.io/docs/language/values/variables.html#variable-definitions-tfvars-files
 [docs/prerequisites.adoc]:https://github.com/oracle-terraform-modules/terraform-oci-compute-instance/blob/main/docs/prerequisites.adoc

--- a/examples/instances_reserved_public_ip/main.tf
+++ b/examples/instances_reserved_public_ip/main.tf
@@ -37,15 +37,14 @@ module "instance_reserved_ip" {
   # operating system parameters
   ssh_authorized_keys = var.ssh_authorized_keys
   # networking parameters
-  assign_public_ip = var.assign_public_ip
-  public_ip        = var.public_ip
-  subnet_ocids     = var.subnet_ocids
+  public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
+  subnet_ocids = var.subnet_ocids
   # storage parameters
   block_storage_sizes_in_gbs = [] # no block volume will be created
   preserve_boot_volume       = false
 }
 
 output "instance_reserved_ip" {
-  description = "ocid of created instances."
+  description = "IP information of the instances provisioned by this module."
   value       = module.instance_reserved_ip.instances_summary
 }

--- a/examples/instances_reserved_public_ip/main.tf
+++ b/examples/instances_reserved_public_ip/main.tf
@@ -19,8 +19,7 @@ provider "oci" {
 
 # # * This module will create 1 Flex Compute Instances, with a reserved public IP
 module "instance_reserved_ip" {
-  source = "../../"
-  # source = "oracle-terraform-modules/compute-instance/oci"
+  source = "oracle-terraform-modules/compute-instance/oci"
   # general oci parameters
   compartment_ocid = var.compartment_ocid
   freeform_tags    = var.freeform_tags

--- a/examples/instances_reserved_public_ip/main.tf
+++ b/examples/instances_reserved_public_ip/main.tf
@@ -1,0 +1,51 @@
+// Copyright (c) 2018, 2021 Oracle and/or its affiliates.
+
+terraform {
+  required_version = ">= 0.13" // terraform version below 0.12 is not tested/supported with this module
+  required_providers {
+    oci = {
+      version = ">= 4.0.0" // force downloading oci-provider compatible with terraform v0.12
+    }
+  }
+}
+
+provider "oci" {
+  tenancy_ocid     = var.tenancy_ocid
+  user_ocid        = var.user_ocid
+  fingerprint      = var.fingerprint
+  private_key_path = var.private_key_path
+  region           = var.region
+}
+
+# # * This module will create 1 Flex Compute Instances, with a reserved public IP
+module "instance_reserved_ip" {
+  source = "../../"
+  # source = "oracle-terraform-modules/compute-instance/oci"
+  # general oci parameters
+  compartment_ocid = var.compartment_ocid
+  freeform_tags    = var.freeform_tags
+  defined_tags     = var.defined_tags
+  # compute instance parameters
+  ad_number                   = null
+  instance_count              = 1
+  instance_display_name       = "instance_reserved_ip"
+  shape                       = var.shape
+  source_ocid                 = var.source_ocid
+  source_type                 = var.source_type
+  instance_flex_memory_in_gbs = 1 # only used if shape is Flex type
+  instance_flex_ocpus         = 1 # only used if shape is Flex type
+  # operating system parameters
+  ssh_authorized_keys = var.ssh_authorized_keys
+  # networking parameters
+  assign_public_ip = var.assign_public_ip
+  public_ip        = var.public_ip
+  subnet_ocids     = var.subnet_ocids
+  # storage parameters
+  block_storage_sizes_in_gbs = [] # no block volume will be created
+  preserve_boot_volume       = false
+}
+
+output "instance_reserved_ip" {
+  description = "ocid of created instances."
+  value       = module.instance_reserved_ip.instances_summary
+}

--- a/examples/instances_reserved_public_ip/terraform.tfvars.example
+++ b/examples/instances_reserved_public_ip/terraform.tfvars.example
@@ -1,0 +1,34 @@
+# Copyright (c) 2019, 2020 Oracle Corporation and/or affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+/*----------------------------------------------------------------------------
+HOW TO USE THIS FILE
+
+1. keep this file in the same folder as your terraform *.tf files
+2. If your terraform config is managed with Git, add the tfvars file to your .gitignore.
+3. Keep your RSA private key outside of your terraform work folder!
+----------------------------------------------------------------------------*/
+
+# provider identity parameters
+
+tenancy_ocid     = "<tenancy OCID>"
+user_ocid        = "<user OCID>"
+fingerprint      = "<PEM key fingerprint>"
+region           = "<region in which to operate, example: us-ashburn-1, eu-frankfurt-1>"
+private_key_path = "<path to the private key that matches the fingerprint above>"
+
+# general oci parameters
+
+compartment_ocid = "<compartment OCID>"
+
+# compute instance parameters
+
+source_ocid  = "<The OCID of an image or a boot volume>"
+
+# operating system parameters
+
+ssh_authorized_keys = "<path to the instance's public key>"
+
+# networking parameters
+
+subnet_ocids = ["<a list of the subnet OCIDs which to create the VNICs in>"]

--- a/examples/instances_reserved_public_ip/variables.tf
+++ b/examples/instances_reserved_public_ip/variables.tf
@@ -112,7 +112,7 @@ variable "ssh_authorized_keys" {
 # networking parameters
 
 variable "public_ip" {
-  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
+  description = "Whether to create a Public IP to attach to primary vnic and which lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
   type        = string
   default     = "NONE"
 }

--- a/examples/instances_reserved_public_ip/variables.tf
+++ b/examples/instances_reserved_public_ip/variables.tf
@@ -111,16 +111,10 @@ variable "ssh_authorized_keys" {
 
 # networking parameters
 
-variable "assign_public_ip" {
-  description = "Whether the VNIC should be assigned a public IP address."
-  type        = bool
-  default     = false
-}
-
 variable "public_ip" {
   description = "OCID of the Public IP to attach to primary vnic."
   type        = string
-  default     = null
+  default     = "NONE"
 }
 
 variable "subnet_ocids" {

--- a/examples/instances_reserved_public_ip/variables.tf
+++ b/examples/instances_reserved_public_ip/variables.tf
@@ -1,0 +1,137 @@
+# Copyright (c) 2019, 2021, Oracle Corporation and/or affiliates.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+# provider identity parameters
+variable "fingerprint" {
+  description = "fingerprint of oci api private key"
+  type        = string
+  # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
+}
+
+variable "private_key_path" {
+  description = "path to oci api private key used"
+  type        = string
+  # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
+}
+
+variable "region" {
+  description = "the oci region where resources will be created"
+  type        = string
+  # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
+  # List of regions: https://docs.cloud.oracle.com/iaas/Content/General/Concepts/regions.htm#ServiceAvailabilityAcrossRegions
+}
+
+variable "tenancy_ocid" {
+  description = "tenancy ocid where to create the sources"
+  type        = string
+  # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
+}
+
+variable "user_ocid" {
+  description = "ocid of user that terraform will use to create the resources"
+  type        = string
+  # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
+}
+
+# general oci parameters
+
+variable "compartment_ocid" {
+  description = "compartment ocid where to create all resources"
+  type        = string
+  # no default value, asking user to explicitly set this variable's value. see codingconventions.adoc
+}
+
+variable "freeform_tags" {
+  description = "simple key-value pairs to tag the resources created using freeform tags."
+  type        = map(string)
+  default     = null
+}
+
+variable "defined_tags" {
+  description = "predefined and scoped to a namespace to tag the resources created using defined tags."
+  type        = map(string)
+  default     = null
+}
+
+# compute instance parameters
+
+variable "instance_ad_number" {
+  description = "The availability domain number of the instance. If none is provided, it will start with AD-1 and continue in round-robin."
+  type        = number
+  default     = 1
+}
+
+variable "instance_count" {
+  description = "Number of identical instances to launch from a single module."
+  type        = number
+  default     = 1
+}
+
+variable "instance_display_name" {
+  description = "(Updatable) A user-friendly name for the instance. Does not have to be unique, and it's changeable."
+  type        = string
+  default     = "module_instance_flex"
+}
+
+variable "instance_flex_memory_in_gbs" {
+  type        = number
+  description = "(Updatable) The total amount of memory available to the instance, in gigabytes."
+  default     = null
+}
+
+variable "instance_flex_ocpus" {
+  type        = number
+  description = "(Updatable) The total number of OCPUs available to the instance."
+  default     = null
+}
+
+variable "shape" {
+  description = "The shape of an instance."
+  type        = string
+  default     = "VM.Standard.E3.Flex"
+}
+
+variable "source_ocid" {
+  description = "The OCID of an image or a boot volume to use, depending on the value of source_type."
+  type        = string
+}
+
+variable "source_type" {
+  description = "The source type for the instance."
+  type        = string
+  default     = "image"
+}
+
+# operating system parameters
+
+variable "ssh_authorized_keys" {
+  description = "Public SSH keys path to be included in the ~/.ssh/authorized_keys file for the default user on the instance."
+  type        = string
+}
+
+# networking parameters
+
+variable "assign_public_ip" {
+  description = "Whether the VNIC should be assigned a public IP address."
+  type        = bool
+  default     = false
+}
+
+variable "public_ip" {
+  description = "OCID of the Public IP to attach to primary vnic."
+  type        = string
+  default     = null
+}
+
+variable "subnet_ocids" {
+  description = "The unique identifiers (OCIDs) of the subnets in which the instance primary VNICs are created."
+  type        = list(string)
+}
+
+# storage parameters
+
+variable "block_storage_sizes_in_gbs" {
+  description = "Sizes of volumes to create and attach to each instance."
+  type        = list(string)
+  default     = [50]
+}

--- a/examples/instances_reserved_public_ip/variables.tf
+++ b/examples/instances_reserved_public_ip/variables.tf
@@ -112,7 +112,7 @@ variable "ssh_authorized_keys" {
 # networking parameters
 
 variable "public_ip" {
-  description = "OCID of the Public IP to attach to primary vnic."
+  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
   type        = string
   default     = "NONE"
 }

--- a/main.tf
+++ b/main.tf
@@ -111,7 +111,7 @@ resource "oci_core_instance" "instance" {
 ##################################
 # Instance Credentials Datasource
 ##################################
-data "oci_core_instance_credentials" "crendential" {
+data "oci_core_instance_credentials" "credential" {
   count       = var.resource_platform != "linux" ? var.instance_count : 0
   instance_id = oci_core_instance.instance[count.index].id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -50,19 +50,19 @@ output "instance_all_attributes" {
   value       = { for k, v in oci_core_instance.this : k => v }
 }
 
-# output "public_ip_all_attributes" {
-#   description = "all attributes of created instance"
-#   value       = { for k, v in oci_core_public_ip.this : k => v }
-# }
-
-output "vnic_attachment_all_attributes" {
-  description = "all attributes of created vnic attachments"
-  value       = { for k, v in data.oci_core_vnic_attachments.this : k => v }
+output "public_ip_all_attributes" {
+  description = "all attributes of created public ip"
+  value       = { for k, v in oci_core_public_ip.this : k => v }
 }
 
 output "private_ips_all_attributes" {
   description = "all attributes of created private ips"
   value       = { for k, v in data.oci_core_private_ips.this : k => v }
+}
+
+output "vnic_attachment_all_attributes" {
+  description = "all attributes of created vnic attachments"
+  value       = { for k, v in data.oci_core_vnic_attachments.this : k => v }
 }
 
 output "volume_all_attributes" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,3 +41,36 @@ output "instance_password" {
   sensitive   = true
   value       = data.oci_core_instance_credentials.this.*.password
 }
+
+# New complete outputs for each resources with provider parity. Auto-updating.
+# Usefull for module composition.
+
+output "instance_all_attributes" {
+  description = "all attributes of created instance"
+  value       = { for k, v in oci_core_instance.this : k => v }
+}
+
+# output "public_ip_all_attributes" {
+#   description = "all attributes of created instance"
+#   value       = { for k, v in oci_core_public_ip.this : k => v }
+# }
+
+output "vnic_attachment_all_attributes" {
+  description = "all attributes of created vnic attachments"
+  value       = { for k, v in data.oci_core_vnic_attachments.this : k => v }
+}
+
+output "private_ips_all_attributes" {
+  description = "all attributes of created private ips"
+  value       = { for k, v in data.oci_core_private_ips.this : k => v }
+}
+
+output "volume_all_attributes" {
+  description = "all attributes of created volumes"
+  value       = { for k, v in oci_core_volume.this : k => v }
+}
+
+output "volume_attachment_all_attributes" {
+  description = "all attributes of created volumes attachments"
+  value       = { for k, v in oci_core_volume_attachment.this : k => v }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,13 +33,13 @@ output "public_ip" {
 
 output "instance_username" {
   description = "Usernames to login to Windows instance. "
-  value       = data.oci_core_instance_credentials.crendential.*.username
+  value       = data.oci_core_instance_credentials.credential.*.username
 }
 
 output "instance_password" {
   description = "Passwords to login to Windows instance. "
   sensitive   = true
-  value       = data.oci_core_instance_credentials.crendential.*.password
+  value       = data.oci_core_instance_credentials.credential.*.password
 }
 
 # New complete outputs for each resources with provider parity. Auto-updating.

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@
 locals {
   instances_details = [
     // display name, Primary VNIC Public/Private IP for each instance
-    for i in oci_core_instance.this : <<EOT
+    for i in oci_core_instance.instance : <<EOT
     ${~i.display_name~}
     Primary-PublicIP: %{if i.public_ip != ""}${i.public_ip~}%{else}N/A%{endif~}
     Primary-PrivateIP: ${i.private_ip~}
@@ -18,28 +18,28 @@ output "instances_summary" {
 
 output "instance_id" {
   description = "ocid of created instances. "
-  value       = oci_core_instance.this.*.id
+  value       = oci_core_instance.instance.*.id
 }
 
 output "private_ip" {
   description = "Private IPs of created instances. "
-  value       = oci_core_instance.this.*.private_ip
+  value       = oci_core_instance.instance.*.private_ip
 }
 
 output "public_ip" {
   description = "Public IPs of created instances. "
-  value       = oci_core_instance.this.*.public_ip
+  value       = oci_core_instance.instance.*.public_ip
 }
 
 output "instance_username" {
   description = "Usernames to login to Windows instance. "
-  value       = data.oci_core_instance_credentials.this.*.username
+  value       = data.oci_core_instance_credentials.crendential.*.username
 }
 
 output "instance_password" {
   description = "Passwords to login to Windows instance. "
   sensitive   = true
-  value       = data.oci_core_instance_credentials.this.*.password
+  value       = data.oci_core_instance_credentials.crendential.*.password
 }
 
 # New complete outputs for each resources with provider parity. Auto-updating.
@@ -47,30 +47,30 @@ output "instance_password" {
 
 output "instance_all_attributes" {
   description = "all attributes of created instance"
-  value       = { for k, v in oci_core_instance.this : k => v }
+  value       = { for k, v in oci_core_instance.instance : k => v }
 }
 
 output "public_ip_all_attributes" {
   description = "all attributes of created public ip"
-  value       = { for k, v in oci_core_public_ip.this : k => v }
+  value       = { for k, v in oci_core_public_ip.public_ip : k => v }
 }
 
 output "private_ips_all_attributes" {
   description = "all attributes of created private ips"
-  value       = { for k, v in data.oci_core_private_ips.this : k => v }
+  value       = { for k, v in data.oci_core_private_ips.private_ips : k => v }
 }
 
 output "vnic_attachment_all_attributes" {
   description = "all attributes of created vnic attachments"
-  value       = { for k, v in data.oci_core_vnic_attachments.this : k => v }
+  value       = { for k, v in data.oci_core_vnic_attachments.vnic_attachment : k => v }
 }
 
 output "volume_all_attributes" {
   description = "all attributes of created volumes"
-  value       = { for k, v in oci_core_volume.this : k => v }
+  value       = { for k, v in oci_core_volume.volume : k => v }
 }
 
 output "volume_attachment_all_attributes" {
   description = "all attributes of created volumes attachments"
-  value       = { for k, v in oci_core_volume_attachment.this : k => v }
+  value       = { for k, v in oci_core_volume_attachment.volume_attachment : k => v }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,7 @@ variable "user_data" {
 # networking parameters
 
 variable "assign_public_ip" {
+  #! Deprecation notice: will be removed at next major release. Use "create_public_ip" instead.
   description = "Whether the VNIC should be assigned a public IP address."
   type        = bool
   default     = false
@@ -147,6 +148,12 @@ variable "private_ips" {
   description = "Private IP addresses of your choice to assign to the VNICs."
   type        = list(string)
   default     = []
+}
+
+variable "public_ip" {
+  description = "OCID of the Public IP to attach to primary vnic."
+  type = string
+  default = null
 }
 
 variable "skip_source_dest_check" {

--- a/variables.tf
+++ b/variables.tf
@@ -151,7 +151,7 @@ variable "private_ips" {
 }
 
 variable "public_ip" {
-  description = "OCID of the Public IP to attach to primary vnic. Valid values are NONE, RESERVED or EPHEMERAL."
+  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
   type        = string
   default     = "NONE"
 

--- a/variables.tf
+++ b/variables.tf
@@ -151,7 +151,7 @@ variable "private_ips" {
 }
 
 variable "public_ip" {
-  description = "Whether to create a Public IP to attach to primary vnic and wwhich lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
+  description = "Whether to create a Public IP to attach to primary vnic and which lifetime. Valid values are NONE, RESERVED or EPHEMERAL."
   type        = string
   default     = "NONE"
 

--- a/variables.tf
+++ b/variables.tf
@@ -126,8 +126,8 @@ variable "user_data" {
 # networking parameters
 
 variable "assign_public_ip" {
-  #! Deprecation notice: will be removed at next major release. Use "create_public_ip" instead.
-  description = "Whether the VNIC should be assigned a public IP address."
+  #! Deprecation notice: will be removed at next major release. Use `var.public_ip` instead.
+  description = "Deprecated: use `var.public_ip` instead. Whether the VNIC should be assigned a public IP address (Always EPHEMERAL)."
   type        = bool
   default     = false
 }
@@ -151,9 +151,20 @@ variable "private_ips" {
 }
 
 variable "public_ip" {
-  description = "OCID of the Public IP to attach to primary vnic."
-  type = string
-  default = null
+  description = "OCID of the Public IP to attach to primary vnic. Valid values are NONE, RESERVED or EPHEMERAL."
+  type        = string
+  default     = "NONE"
+
+  validation {
+    condition     = contains(["NONE", "RESERVED", "EPHEMERAL"], var.public_ip)
+    error_message = "Accepted values are NONE, RESERVED or EPHEMERAL."
+  }
+}
+
+variable "public_ip_display_name" {
+  description = "(Updatable) A user-friendly name. Does not have to be unique, and it's changeable."
+  type        = string
+  default     = null
 }
 
 variable "skip_source_dest_check" {


### PR DESCRIPTION
## Feature description

This feature allow the module user to provision an instance with a reserved public IP.
The user still have the possibility to provision an instance without a public IP or with an ephemeral public IP.

The argument `assign_public_ip` from the ` create_vnic_details` block on `oci_core_instance` is not used anymore, as it do not allow assigning a reserved public IP.

## New resources

- `oci_core_public_ip`

## Control variable

- `var.public_ip` as string with the following accepted values: NONE, RESERVED or EPHEMERAL
- `var.public_ip_display_name` as string, default to instance's display name