### PR TITLE
feat(storage): add support for boot volume backup policy

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,7 +14,7 @@ Given a version number MAJOR.MINOR.PATCH:
 * MINOR version when adding functionality in a backwards compatible manner,
 * PATCH version when making backwards compatible bug fixes.
 
-== 2.2.0 - unreleased
+== 2.2.0 - 2021-09-27
 
 === Deprecated
 
@@ -27,7 +27,7 @@ Given a version number MAJOR.MINOR.PATCH:
 * Add "module watermark" freeform tags: module defined and user defined freeform tags are merged on the final resource
 * Add support to provide the `ssh_authorized_keys` argument as a string or as a file (Fix #67 #70)
 * Add support for reserved Public IP on instance first VNIC (fix #55)
-* [ ] Define a backup policy for boot volume and additional block volumes (fix #64)
+* Add support for backup policy on boot volume (fix #64)
 * Add new outputs for each provisioned resources: "all_attributes" outputs have full provider coverage and are auto-updating.
 
 === Documentation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This module provides an easy way to launch compute instances with advanced settings and good practices embedded.
 
-On top of the compute instance capabilities, this module can also provision and attach additional Block Volumes to the instances.
+On top of the compute instance capabilities, this module can also:
+
+- provision and attach additional Block Volumes to the instances,
+- assign a reserved public IP, instead of using Ephemeral,
+- assign a backup policy for boot volumes
 
 **Please Note:**
 
@@ -46,8 +50,8 @@ module "instance" {
   instance_display_name      = var.instance_display_name
   source_ocid                = var.source_ocid
   subnet_ocids               = var.subnet_ocids
-  assign_public_ip           = var.assign_public_ip
-  ssh_authorized_keys        = var.ssh_authorized_keys_file
+  public_ip                  = var.public_ip # NONE, RESERVED or EPHEMERAL
+  ssh_public_keys            = var.ssh_public_keys
   block_storage_sizes_in_gbs = [50]
   shape                      = var.shape
 }

--- a/docs/instance_ssh_keys.adoc
+++ b/docs/instance_ssh_keys.adoc
@@ -51,7 +51,7 @@ module "instance" {
 
 variable "my_public_ssh_key" {
   type    = string
-  default = "<ssh public key>" 
+  default = "<ssh public key>"
 }
 ----
 

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -1,3 +1,5 @@
+// BEGIN_TF_DOCS
+
 == Requirements
 
 [cols="a,a",options="header,autowidth"]
@@ -6,7 +8,6 @@
 |[[requirement_terraform]] <<requirement_terraform,terraform>> |>= 0.12
 |[[requirement_oci]] <<requirement_oci,oci>> |>= 3.27
 |===
-
 == Providers
 
 [cols="a,a",options="header,autowidth"]
@@ -14,11 +15,6 @@
 |Name |Version
 |[[provider_oci]] <<provider_oci,oci>> |4.17.0
 |===
-
-== Modules
-
-No modules.
-
 == Resources
 
 [cols="a,a",options="header,autowidth"]
@@ -28,14 +24,15 @@ No modules.
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_public_ip[oci_core_public_ip.public_ip] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume[oci_core_volume.volume] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_attachment[oci_core_volume_attachment.volume_attachment] |resource
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_backup_policy_assignment[oci_core_volume_backup_policy_assignment.boot_volume_backup_policy] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.credential] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_private_ips[oci_core_private_ips.private_ips] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_shapes[oci_core_shapes.ad1] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_subnet[oci_core_subnet.instance_subnet] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_vnic_attachments[oci_core_vnic_attachments.vnic_attachment] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_volume_backup_policies[oci_core_volume_backup_policies.default_backup_policies] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/identity_availability_domains[oci_identity_availability_domains.ad] |data source
 |===
-
 == Inputs
 
 [cols="a,a,a,a,a",options="header,autowidth"]
@@ -63,6 +60,12 @@ No modules.
 |Sizes of volumes to create and attach to each instance.
 |`list(number)`
 |`[]`
+|no
+
+|[[input_boot_volume_backup_policy]] <<input_boot_volume_backup_policy,boot_volume_backup_policy>>
+|Choose between default backup policies : Gold, Silver, Bronze. Use Disabled to affect no backup policy on the Boot Volume.
+|`string`
+|`"disabled"`
 |no
 
 |[[input_boot_volume_size_in_gbs]] <<input_boot_volume_size_in_gbs,boot_volume_size_in_gbs>>
@@ -228,7 +231,6 @@ No modules.
 |no
 
 |===
-
 == Outputs
 
 [cols="a,a",options="header,autowidth"]
@@ -247,3 +249,5 @@ No modules.
 |[[output_volume_all_attributes]] <<output_volume_all_attributes,volume_all_attributes>> |all attributes of created volumes
 |[[output_volume_attachment_all_attributes]] <<output_volume_attachment_all_attributes,volume_attachment_all_attributes>> |all attributes of created volumes attachments
 |===
+
+// END_TF_DOCS

--- a/examples/instances_fixed_shape/main.tf
+++ b/examples/instances_fixed_shape/main.tf
@@ -37,6 +37,7 @@ module "instance_nonflex" {
   public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
   subnet_ocids = var.subnet_ocids
   # storage parameters
+  boot_volume_backup_policy  = var.boot_volume_backup_policy
   block_storage_sizes_in_gbs = var.block_storage_sizes_in_gbs
 }
 
@@ -68,6 +69,7 @@ module "instance_nonflex_custom" {
   public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
   subnet_ocids = var.subnet_ocids
   # storage parameters
+  boot_volume_backup_policy  = var.boot_volume_backup_policy
   block_storage_sizes_in_gbs = [] # no block volume will be created
 }
 

--- a/examples/instances_fixed_shape/terraform.tfvars.example
+++ b/examples/instances_fixed_shape/terraform.tfvars.example
@@ -33,6 +33,10 @@ ssh_public_keys = <<EOT
 <ssh_public_key_3>
 EOT
 
+# storage parameters
+
+boot_volume_backup_policy = "<the backup policy name>" # gold, silver, bronze, disabled
+
 # networking parameters
 
 subnet_ocids = ["<a list of the subnet OCIDs which to create the VNICs in>"]

--- a/examples/instances_fixed_shape/variables.tf
+++ b/examples/instances_fixed_shape/variables.tf
@@ -131,6 +131,12 @@ variable "subnet_ocids" {
 
 # storage parameters
 
+variable "boot_volume_backup_policy" {
+  description = "Choose between default backup policies : Gold, Silver, Bronze. Use Disabled to affect no backup policy on the Boot Volume."
+  type        = string
+  default     = "disabled"
+}
+
 variable "block_storage_sizes_in_gbs" {
   description = "Sizes of volumes to create and attach to each instance."
   type        = list(string)

--- a/examples/instances_flex_shape/main.tf
+++ b/examples/instances_flex_shape/main.tf
@@ -40,6 +40,7 @@ module "instance_flex" {
   public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
   subnet_ocids = var.subnet_ocids
   # storage parameters
+  boot_volume_backup_policy  = var.boot_volume_backup_policy
   block_storage_sizes_in_gbs = var.block_storage_sizes_in_gbs
 }
 
@@ -70,6 +71,7 @@ output "instance_flex" {
 #   public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
 #   subnet_ocids     = var.subnet_ocids
 #   # storage parameters
+#   boot_volume_backup_policy = "silver"
 #   block_storage_sizes_in_gbs = [] # no block volume will be created
 # }
 

--- a/examples/instances_flex_shape/terraform.tfvars.example
+++ b/examples/instances_flex_shape/terraform.tfvars.example
@@ -33,6 +33,10 @@ ssh_public_keys = <<EOT
 <ssh_public_key_3>
 EOT
 
+# storage parameters
+
+boot_volume_backup_policy = "<the backup policy name>" # gold, silver, bronze, disabled
+
 # networking parameters
 
 subnet_ocids = ["<a list of the subnet OCIDs which to create the VNICs in>"]

--- a/examples/instances_flex_shape/variables.tf
+++ b/examples/instances_flex_shape/variables.tf
@@ -132,6 +132,12 @@ variable "subnet_ocids" {
 
 # storage parameters
 
+variable "boot_volume_backup_policy" {
+  description = "Choose between default backup policies : Gold, Silver, Bronze. Use Disabled to affect no backup policy on the Boot Volume."
+  type        = string
+  default     = "disabled"
+}
+
 variable "block_storage_sizes_in_gbs" {
   description = "Sizes of volumes to create and attach to each instance."
   type        = list(string)

--- a/examples/instances_reserved_public_ip/README.md
+++ b/examples/instances_reserved_public_ip/README.md
@@ -1,4 +1,4 @@
-# Creating Compute Instances using Flex shape
+# Creating Compute Instances with a reserved public IP
 
 This example illustrates how to use this module to creates compute instances with a reserved public IP.
 

--- a/examples/instances_reserved_public_ip/main.tf
+++ b/examples/instances_reserved_public_ip/main.tf
@@ -34,11 +34,12 @@ module "instance_reserved_ip" {
   instance_flex_memory_in_gbs = 1 # only used if shape is Flex type
   instance_flex_ocpus         = 1 # only used if shape is Flex type
   # operating system parameters
-  ssh_authorized_keys = var.ssh_authorized_keys
+  ssh_public_keys = var.ssh_public_keys
   # networking parameters
   public_ip    = var.public_ip # NONE, RESERVED or EPHEMERAL
   subnet_ocids = var.subnet_ocids
   # storage parameters
+  boot_volume_backup_policy  = var.boot_volume_backup_policy
   block_storage_sizes_in_gbs = [] # no block volume will be created
   preserve_boot_volume       = false
 }

--- a/examples/instances_reserved_public_ip/terraform.tfvars.example
+++ b/examples/instances_reserved_public_ip/terraform.tfvars.example
@@ -27,7 +27,15 @@ source_ocid  = "<The OCID of an image or a boot volume>"
 
 # operating system parameters
 
-ssh_authorized_keys = "<path to the instance's public key>"
+ssh_public_keys = <<EOT
+<ssh_public_key_1>
+<ssh_public_key_2>
+<ssh_public_key_3>
+EOT
+
+# storage parameters
+
+boot_volume_backup_policy = "<the backup policy name>" # gold, silver, bronze, disabled
 
 # networking parameters
 

--- a/examples/instances_reserved_public_ip/variables.tf
+++ b/examples/instances_reserved_public_ip/variables.tf
@@ -104,9 +104,10 @@ variable "source_type" {
 
 # operating system parameters
 
-variable "ssh_authorized_keys" {
-  description = "Public SSH keys path to be included in the ~/.ssh/authorized_keys file for the default user on the instance."
+variable "ssh_public_keys" {
+  description = "Public SSH keys to be included in the ~/.ssh/authorized_keys file for the default user on the instance. To provide multiple keys, see docs/instance_ssh_keys.adoc."
   type        = string
+  default     = null
 }
 
 # networking parameters
@@ -123,6 +124,12 @@ variable "subnet_ocids" {
 }
 
 # storage parameters
+
+variable "boot_volume_backup_policy" {
+  description = "Choose between default backup policies : Gold, Silver, Bronze. Use Disabled to affect no backup policy on the Boot Volume."
+  type        = string
+  default     = "disabled"
+}
 
 variable "block_storage_sizes_in_gbs" {
   description = "Sizes of volumes to create and attach to each instance."

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 locals {
   instances_details = [

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,5 @@
-// Copyright (c) 2018, 2021, Oracle and/or its affiliates.
+# Copyright (c) 2018, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
 
 # general oci parameters
 
@@ -204,6 +205,17 @@ variable "block_storage_sizes_in_gbs" {
 #   type        = bool
 #   default     = true
 # }
+
+variable "boot_volume_backup_policy" {
+  description = "Choose between default backup policies : Gold, Silver, Bronze. Use Disabled to affect no backup policy on the Boot Volume."
+  type        = string
+  default     = "disabled"
+
+  validation {
+    condition     = contains(["gold", "silver", "bronze", "disabled"], var.boot_volume_backup_policy)
+    error_message = "Accepted values are gold, silver, bronze or disabled (case sensitive)."
+  }
+}
 
 variable "boot_volume_size_in_gbs" {
   description = "The size of the boot volume in GBs."

--- a/volumes.tf
+++ b/volumes.tf
@@ -1,0 +1,44 @@
+# Copyright (c) 2018, 2021 Oracle Corporation and/or affiliates.  All rights reserved.
+# Licensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl
+
+#############
+# Boot Volume
+#############
+
+# Assign a backup policy to instance's boot volume
+
+resource "oci_core_volume_backup_policy_assignment" "boot_volume_backup_policy" {
+  # * The boot volume backup policy is controlled by var.boot_volume_backup_policy.
+  # * You can choose between OCI default backup policies : Gold, Silver, Bronze.
+  # * If you set the variable to "disabled", no backup policy will be applied to the boot volume.
+  count     = var.boot_volume_backup_policy != "disabled" ? var.instance_count : 0
+  asset_id  = oci_core_instance.instance.*.boot_volume_id[count.index]
+  policy_id = local.backup_policies[var.boot_volume_backup_policy]
+}
+
+#########
+# Volume
+#########
+resource "oci_core_volume" "volume" {
+  count               = var.instance_count * length(var.block_storage_sizes_in_gbs)
+  availability_domain = oci_core_instance.instance[count.index % var.instance_count].availability_domain
+  compartment_id      = var.compartment_ocid
+  display_name        = "${oci_core_instance.instance[count.index % var.instance_count].display_name}_volume${floor(count.index / var.instance_count)}"
+  size_in_gbs = element(
+    var.block_storage_sizes_in_gbs,
+    floor(count.index / var.instance_count),
+  )
+  freeform_tags = local.merged_freeform_tags
+  defined_tags  = var.defined_tags
+}
+
+####################
+# Volume Attachment
+####################
+resource "oci_core_volume_attachment" "volume_attachment" {
+  count           = var.instance_count * length(var.block_storage_sizes_in_gbs)
+  attachment_type = var.attachment_type
+  instance_id     = oci_core_instance.instance[count.index % var.instance_count].id
+  volume_id       = oci_core_volume.volume[count.index].id
+  use_chap        = var.use_chap
+}


### PR DESCRIPTION
This feature allows the module user to set a backup policy for boot volume. The user can choose one of the existing default backup policy or affect none.

These keywords are interpreted: "gold", "silver", "bronze", "disabled".

Later iteration on this feature should allows to specify the OCID of an existing backup policy to allow usage of customer-defined backup policies, but also extend this feature to support backup policy on additional block volumes.

Fix: #64