### PR TITLE
fix: build the shape list on the current AD

### DIFF
--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -26,7 +26,7 @@
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_backup_policy_assignment[oci_core_volume_backup_policy_assignment.boot_volume_backup_policy] |resource
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_instance_credentials[oci_core_instance_credentials.credential] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_private_ips[oci_core_private_ips.private_ips] |data source
-|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_shapes[oci_core_shapes.ad1] |data source
+|https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_shapes[oci_core_shapes.current_ad] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_subnet[oci_core_subnet.instance_subnet] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_vnic_attachments[oci_core_vnic_attachments.vnic_attachment] |data source
 |https://registry.terraform.io/providers/hashicorp/oci/latest/docs/data-sources/core_volume_backup_policies[oci_core_volume_backup_policies.default_backup_policies] |data source


### PR DESCRIPTION
close #87 

The list of shapes is now built on the given availability domain

Signed-off-by: Andrea Marchesini <andrea.marchesini@oracle.com>