### PR TITLE
feat: add support for cloud agent plugins

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,17 @@ Given a version number MAJOR.MINOR.PATCH:
 * MINOR version when adding functionality in a backwards compatible manner,
 * PATCH version when making backwards compatible bug fixes.
 
+== 2.4.0 - unreleased
+
+=== New features
+
+* Add support for burstable instances (fix #66)
+* Add support for Oracle Cloud Agent pulgins configuration (fix #17)
+
+=== Fixes
+
+* Instance display name no longer automatically append a number when only one instance is configured
+
 == 2.3.0 - 2021-11-12
 
 === New features

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -12,7 +12,7 @@
 [cols="a,a",options="header,autowidth"]
 |===
 |Name |Version
-|[[provider_oci]] <<provider_oci,oci>> |>= 3.27
+|[[provider_oci]] <<provider_oci,oci>> |4.61.0
 |===
 == Resources
 
@@ -55,6 +55,12 @@
 |`"paravirtualized"`
 |no
 
+|[[input_baseline_ocpu_utilization]] <<input_baseline_ocpu_utilization,baseline_ocpu_utilization>>
+|(Updatable) The baseline OCPU utilization for a subcore burstable VM instance
+|`string`
+|`"BASELINE_1_1"`
+|no
+
 |[[input_block_storage_sizes_in_gbs]] <<input_block_storage_sizes_in_gbs,block_storage_sizes_in_gbs>>
 |Sizes of volumes to create and attach to each instance.
 |`list(number)`
@@ -71,6 +77,28 @@
 |The size of the boot volume in GBs.
 |`number`
 |`null`
+|no
+
+|[[input_cloud_agent_plugins]] <<input_cloud_agent_plugins,cloud_agent_plugins>>
+|Whether each Oracle Cloud Agent plugins should be ENABLED or DISABLED.
+|`map(string)`
+|
+
+[source]
+----
+{
+  "autonomous_linux": "ENABLED",
+  "bastion": "ENABLED",
+  "block_volume_mgmt": "DISABLED",
+  "custom_logs": "ENABLED",
+  "management": "DISABLED",
+  "monitoring": "ENABLED",
+  "osms": "ENABLED",
+  "run_command": "ENABLED",
+  "vulnerability_scanning": "ENABLED"
+}
+----
+
 |no
 
 |[[input_compartment_ocid]] <<input_compartment_ocid,compartment_ocid>>
@@ -119,12 +147,6 @@
 |(Updatable) The total amount of memory available to the instance, in gigabytes.
 |`number`
 |`null`
-|no
-
-|[[baseline_ocpu_utilization]] <<input_baseline_ocpu_utilization,baseline_ocpu_utilization>>
-|(Updatable) The baseline OCPU utilization for a subcore burstable VM instance.
-|`string`
-|`BASELINE_1_1`
 |no
 
 |[[input_instance_flex_ocpus]] <<input_instance_flex_ocpus,instance_flex_ocpus>>

--- a/examples/instances_fixed_shape/main.tf
+++ b/examples/instances_fixed_shape/main.tf
@@ -32,6 +32,17 @@ module "instance_nonflex" {
   shape                 = var.shape
   source_ocid           = var.source_ocid
   source_type           = var.source_type
+  cloud_agent_plugins = {
+    autonomous_linux       = "ENABLED"
+    bastion                = "ENABLED"
+    vulnerability_scanning = "ENABLED"
+    osms                   = "ENABLED"
+    management             = "DISABLED"
+    custom_logs            = "ENABLED"
+    run_command            = "ENABLED"
+    monitoring             = "ENABLED"
+    block_volume_mgmt      = "DISABLED"
+  }
   # operating system parameters
   ssh_public_keys = var.ssh_public_keys
   # networking parameters

--- a/examples/instances_flex_shape/main.tf
+++ b/examples/instances_flex_shape/main.tf
@@ -35,7 +35,18 @@ module "instance_flex" {
   source_type                 = var.source_type
   instance_flex_memory_in_gbs = var.instance_flex_memory_in_gbs # only used if shape is Flex type
   instance_flex_ocpus         = 1                               # only used if shape is Flex type
-  baseline_ocpu_utilization = var.baseline_ocpu_utilization
+  baseline_ocpu_utilization   = var.baseline_ocpu_utilization
+  cloud_agent_plugins = {
+    autonomous_linux       = "ENABLED"
+    bastion                = "ENABLED"
+    vulnerability_scanning = "ENABLED"
+    osms                   = "ENABLED"
+    management             = "DISABLED"
+    custom_logs            = "ENABLED"
+    run_command            = "ENABLED"
+    monitoring             = "ENABLED"
+    block_volume_mgmt      = "DISABLED"
+  }
   # operating system parameters
   ssh_public_keys = var.ssh_public_keys
   # networking parameters

--- a/main.tf
+++ b/main.tf
@@ -78,9 +78,55 @@ resource "oci_core_instance" "instance" {
   shape_config {
     // If shape name contains ".Flex" and instance_flex inputs are not null, use instance_flex inputs values for shape_config block
     // Else use values from data.oci_core_shapes.current_ad for var.shape
-    memory_in_gbs = local.shape_is_flex == true && var.instance_flex_memory_in_gbs != null ? var.instance_flex_memory_in_gbs : local.shapes_config[var.shape]["memory_in_gbs"]
-    ocpus         = local.shape_is_flex == true && var.instance_flex_ocpus != null ? var.instance_flex_ocpus : local.shapes_config[var.shape]["ocpus"]
+    memory_in_gbs             = local.shape_is_flex == true && var.instance_flex_memory_in_gbs != null ? var.instance_flex_memory_in_gbs : local.shapes_config[var.shape]["memory_in_gbs"]
+    ocpus                     = local.shape_is_flex == true && var.instance_flex_ocpus != null ? var.instance_flex_ocpus : local.shapes_config[var.shape]["ocpus"]
     baseline_ocpu_utilization = var.baseline_ocpu_utilization
+  }
+
+  agent_config {
+    are_all_plugins_disabled = false
+    is_management_disabled   = false
+    is_monitoring_disabled   = false
+
+    # ! provider seems to have a bug with plugin_config stanzas below
+    // this configuration is applied at first resource creation
+    // subsequent updates are detected as changes by terraform but seems to be ignored by the provider ...
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.autonomous_linux
+      name          = "Oracle Autonomous Linux"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.bastion
+      name          = "Bastion"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.block_volume_mgmt
+      name          = "Block Volume Management"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.custom_logs
+      name          = "Custom Logs Monitoring"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.management
+      name          = "Management Agent"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.monitoring
+      name          = "Compute Instance Monitoring"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.osms
+      name          = "OS Management Service Agent"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.run_command
+      name          = "Compute Instance Run Command"
+    }
+    plugins_config {
+      desired_state = var.cloud_agent_plugins.vulnerability_scanning
+      name          = "Vulnerability Scanning"
+    }
   }
 
   create_vnic_details {

--- a/variables.tf
+++ b/variables.tf
@@ -91,6 +91,23 @@ variable "shape" {
   default     = "VM.Standard2.1"
 }
 
+variable "cloud_agent_plugins" {
+  description = "Whether each Oracle Cloud Agent plugins should be ENABLED or DISABLED."
+  type        = map(string)
+  default = {
+    autonomous_linux       = "ENABLED"
+    bastion                = "ENABLED"
+    block_volume_mgmt      = "DISABLED"
+    custom_logs            = "ENABLED"
+    management             = "DISABLED"
+    monitoring             = "ENABLED"
+    osms                   = "ENABLED"
+    run_command            = "ENABLED"
+    vulnerability_scanning = "ENABLED"
+  }
+  #* need to craft a validation condition at some point
+}
+
 variable "baseline_ocpu_utilization" {
   description = "(Updatable) The baseline OCPU utilization for a subcore burstable VM instance"
   type        = string


### PR DESCRIPTION
This change adds a new input variable `var.cloud_agent_plugins` type `map(string)`. It allows to individually enable or disable an Oracle Cloud Agent plugin.

This new input is optional for the module user. If no value is provided, the following default will be applied:

``` HCL
  {
    autonomous_linux       = "ENABLED"
    bastion                = "ENABLED"
    block_volume_mgmt      = "DISABLED"
    custom_logs            = "ENABLED"
    management             = "DISABLED"
    monitoring             = "ENABLED"
    osms                   = "ENABLED"
    run_command            = "ENABLED"
    vulnerability_scanning = "ENABLED"
  }
```

Fixes: #17 

    # ! provider seems to have a bug with plugin_config the stanza
    // the configuration is applied at first resource creation
    // subsequent updates are detected as changes by Terraform but seems to be ignored by oci provider.