### PR TITLE
fix: burstable instances example variable declaration

### DIFF
--- a/examples/instances_fixed_shape/main.tf
+++ b/examples/instances_fixed_shape/main.tf
@@ -19,6 +19,7 @@ provider "oci" {
 
 # * This module will create a shape-based Compute Instance. OCPU and memory values are defined by the provided value for shape.
 module "instance_nonflex" {
+  # source = "git::https://github.com/oracle-terraform-modules/terraform-oci-compute-instance" ## use this to test directly from Github HEAD
   source = "oracle-terraform-modules/compute-instance/oci"
   # general oci parameters
   compartment_ocid = var.compartment_ocid
@@ -32,17 +33,7 @@ module "instance_nonflex" {
   shape                 = var.shape
   source_ocid           = var.source_ocid
   source_type           = var.source_type
-  cloud_agent_plugins = {
-    autonomous_linux       = "ENABLED"
-    bastion                = "ENABLED"
-    vulnerability_scanning = "ENABLED"
-    osms                   = "ENABLED"
-    management             = "DISABLED"
-    custom_logs            = "ENABLED"
-    run_command            = "ENABLED"
-    monitoring             = "ENABLED"
-    block_volume_mgmt      = "DISABLED"
-  }
+  cloud_agent_plugins   = var.cloud_agent_plugins
   # operating system parameters
   ssh_public_keys = var.ssh_public_keys
   # networking parameters

--- a/examples/instances_fixed_shape/variables.tf
+++ b/examples/instances_fixed_shape/variables.tf
@@ -102,6 +102,21 @@ variable "shape" {
   default     = "VM.Standard2.1"
 }
 
+variable "cloud_agent_plugins" {
+  description = "Whether each Oracle Cloud Agent plugins should be ENABLED or DISABLED."
+  type        = map(string)
+  default = {
+    autonomous_linux       = "ENABLED"
+    bastion                = "ENABLED"
+    block_volume_mgmt      = "DISABLED"
+    custom_logs            = "ENABLED"
+    management             = "DISABLED"
+    monitoring             = "ENABLED"
+    osms                   = "ENABLED"
+    run_command            = "ENABLED"
+    vulnerability_scanning = "ENABLED"
+  }
+}
 variable "source_ocid" {
   description = "The OCID of an image or a boot volume to use, depending on the value of source_type."
   type        = string

--- a/examples/instances_flex_shape/main.tf
+++ b/examples/instances_flex_shape/main.tf
@@ -20,6 +20,7 @@ provider "oci" {
 # * This module will create a Flex Compute Instance, using default values: 1 OCPU, 16 GB memory.
 # * `instance_flex_memory_in_gbs` and `instance_flex_ocpus` are not provided: default values will be applied.
 module "instance_flex" {
+  # source = "git::https://github.com/oracle-terraform-modules/terraform-oci-compute-instance" ## use this to test directly from Github HEAD
   source = "oracle-terraform-modules/compute-instance/oci"
   # general oci parameters
   compartment_ocid = var.compartment_ocid

--- a/examples/instances_flex_shape/variables.tf
+++ b/examples/instances_flex_shape/variables.tf
@@ -102,6 +102,12 @@ variable "shape" {
   default     = "VM.Standard.E3.Flex"
 }
 
+variable "baseline_ocpu_utilization" {
+  description = "(Updatable) The baseline OCPU utilization for a subcore burstable VM instance"
+  type        = string
+  default     = "BASELINE_1_1"
+}
+
 variable "source_ocid" {
   description = "The OCID of an image or a boot volume to use, depending on the value of source_type."
   type        = string


### PR DESCRIPTION
PR #89 introduce a new variable to support burstable isntances.

The example `instances_flex_shape` is updated to demonstrate this feature usage but the module calls a variable ta do not exist in the configuration.