### PR TITLE
Fix: instance_count distribute again instances per AD when ad_number == null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ data "oci_core_subnet" "instance_subnet" {
 // This will not check quota and limits for AD requested at resource creation
 data "oci_core_shapes" "current_ad" {
   compartment_id      = var.compartment_ocid
-  availability_domain = local.ADs[(var.ad_number - 1)]
+  availability_domain = var.ad_number == null ? element(local.ADs, 0) : element(local.ADs, var.ad_number - 1)
 }
 
 locals {


### PR DESCRIPTION
when `var.ad_number == null`,  `data.oci_core_shapes.current_ad` cannot be created anymore.
We currently rely on `var.ad_number == null` to provision instances in each AD in a round robin manner when `var.instance_count` is used.

Fixes: #93