### PR TITLE
Add capacity types: on-demand, preemptible, reserved, dedicated

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,7 +14,13 @@ Given a version number MAJOR.MINOR.PATCH:
 * MINOR version when adding functionality in a backwards compatible manner,
 * PATCH version when making backwards compatible bug fixes.
 
-== 2.4.0 - unreleased
+== 2.5.0 - unreleased
+
+* Add support for Capacity Types: On-demand, Preemptible, Reserved, Dedicated (fix #96)
+
+=== New features
+
+== 2.4.0 - 2022-06-06
 
 === New features
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -34,7 +34,7 @@ You should ensure that your documentation changes include the following:
 * Don't forget how important the documentation is, especially for examples: we would love it if you updated the `main.tf` and `variables.tf` in the `examples/` folder. A simple example is fine.
 * You should also update the code examples in link:examples/README.md[examples/README]: it contains sample code blocks that probably needs to be updated to reflect your changes
 
-NOTE: Tables on xref:docs/terraformoptions.adoc[docs/terraformoptions] are automatically generated using terraform-docs. The maintainer will refesh this document before release, but variables must be defined as described in xref:doc/codingconventions.adoc[docs/codingconventions].
+NOTE: Tables on xref:docs/terraformoptions.adoc[docs/terraformoptions] are automatically generated using terraform-docs. The maintainer will refesh this document before release, but variables must be defined as described in xref:docs/codingconventions.adoc[docs/codingconventions].
 
 == How to contribute to this repository
 

--- a/CONTRIBUTORS.adoc
+++ b/CONTRIBUTORS.adoc
@@ -9,8 +9,9 @@ _Members can merge code to master_
 
 == Code Contributors
 
-_Code Contributors have a least one merged PR in the code base of the project_
+_Code Contributors have at least one merged PR in the code base of the project_
 
 - https://github.com/yimw[@yimw]
 - https://github.com/alexng-canuck[@alexng-canuck]
 - https://github.com/aorcl[@aorcl]
+- https://github.com/vadyochik[@vadyochik]

--- a/main.tf
+++ b/main.tf
@@ -76,6 +76,19 @@ resource "oci_core_instance" "instance" {
     baseline_ocpu_utilization = var.baseline_ocpu_utilization
   }
 
+  dynamic "preemptible_instance_config" {
+    for_each = var.capacity_type == "preemptible" ? [1] : []
+    content {
+      preemption_action {
+        type                 = lookup(var.preemption_action, "type", "TERMINATE")
+        preserve_boot_volume = lookup(var.preemption_action, "preserve_boot_volume", false)
+      }
+    }
+  }
+
+  capacity_reservation_id = var.capacity_type == "reserved" ? var.capacity_reservation_id : null
+  dedicated_vm_host_id    = var.capacity_type == "dedicated" ? var.dedicated_vm_host_id : null
+
   agent_config {
     are_all_plugins_disabled = false
     is_management_disabled   = false

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,41 @@ variable "source_type" {
   default     = "image"
 }
 
+variable "capacity_type" {
+  description = "Host capacity type to use when launching compute instances: On-demand, Preemptible, Reserved or Dedicated."
+  type        = string
+  default     = "on-demand"
+
+  validation {
+    condition     = contains(["on-demand", "preemptible", "reserved", "dedicated"], var.capacity_type)
+    error_message = "Accepted values are on-demand, preemptible, reserved or dedicated."
+  }
+}
+
+variable "preemption_action" {
+  description = "The action to run when the preemptible instance is interrupted for eviction."
+  type = object({
+    type                 = string
+    preserve_boot_volume = bool
+  })
+  default = {
+    type                 = "TERMINATE"
+    preserve_boot_volume = false
+  }
+}
+
+variable "capacity_reservation_id" {
+  description = "(Optional) (Updatable) The OCID of the compute capacity reservation this instance is launched under."
+  type        = string
+  default     = null
+}
+
+variable "dedicated_vm_host_id" {
+  description = "(Optional) The OCID of dedicated VM host."
+  type        = string
+  default     = null
+}
+
 # operating system parameters
 
 variable "extended_metadata" {


### PR DESCRIPTION
Add support for [Capacity Types](https://docs.oracle.com/en-us/iaas/Content/Compute/Concepts/capacity-types.htm) (#96)

Defaults to **on-demand** (the same as it was before this code). To run preemptible instances set `capacity_type` var to **preemptible**.

Signed-off-by: Vadym Agarkov <vadyochik@proton.me>