### PR TITLE
Issue #109: add new input `instance_launch_options`

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -20,6 +20,7 @@ Given a version number MAJOR.MINOR.PATCH:
 
 * Add support for burstable instances (fix #66)
 * Add support for Oracle Cloud Agent pulgins configuration (fix #17)
+* Add support for instance options from `launch_options` block (Issue #109)
 
 === Fixes
 

--- a/CONTRIBUTORS.adoc
+++ b/CONTRIBUTORS.adoc
@@ -14,3 +14,4 @@ _Code Contributors have a least one merged PR in the code base of the project_
 - https://github.com/yimw[@yimw]
 - https://github.com/alexng-canuck[@alexng-canuck]
 - https://github.com/aorcl[@aorcl]
+- https://github.com/silent-at-gh[@silent-at-gh]

--- a/docs/terraformoptions.adoc
+++ b/docs/terraformoptions.adoc
@@ -156,6 +156,20 @@
 |`null`
 |no
 
+|[[input_instance_launch_options]] <<input_instance_launch_options,instance_launch_options>>
+|Options for tuning the compatibility and performance of VM shapes.
+Valid option names and their values are:
+
+  * __boot_volume_type__ - `ISCSI`, `SCSI`, `IDE`, `VFIO` or `PARAVIRTUALIZED`
+  * __network_type__ - `E1000`, `VFIO` or `PARAVIRTUALIZED`
+  * __firmware__ - `BIOS` or `UEFI_64`
+  * __remote_data_volume_type__ - `ISCSI`, `SCSI`, `IDE`, `VFIO` or `PARAVIRTUALIZED`
+  * __is_consistent_volume_naming_enabled__ - `true` or `false`
+  * __is_pv_encryption_in_transit_enabled__ - `true` of `false`
+|`map(any)`
+|`{}`
+|no
+
 |[[input_instance_state]] <<input_instance_state,instance_state>>
 |(Updatable) The target state for the instance. Could be set to RUNNING or STOPPED.
 |`string`

--- a/main.tf
+++ b/main.tf
@@ -154,8 +154,23 @@ resource "oci_core_instance" "instance" {
     source_type             = var.source_type
   }
 
+
+  dynamic "launch_options" {
+    // This one is optional or user may specify zero (or more) options
+    for_each = length(keys(var.instance_launch_options)) > 0 ? [var.instance_launch_options] : []
+    content {
+      boot_volume_type                    = try(launch_options.value.boot_volume_type, null)
+      firmware                            = try(launch_options.value.firmware, null)
+      is_consistent_volume_naming_enabled = try(launch_options.value.is_consistent_volume_naming_enabled, null)
+      is_pv_encryption_in_transit_enabled = try(launch_options.value.is_pv_encryption_in_transit_enabled, null)
+      network_type                        = try(launch_options.value.network_type, null)
+      remote_data_volume_type             = try(launch_options.value.remote_data_volume_type, null)
+    }
+  }
+
   freeform_tags = local.merged_freeform_tags
   defined_tags  = var.defined_tags
+
 
   timeouts {
     create = var.instance_timeout


### PR DESCRIPTION
oci_core_instance resource supports optional inputs from "launch_options" block. In some use cases where instances are launched from a customized images it is required to tune some of the launch options so that instances could boot properly. The current implementation of the compute instance module has lacked it. Hence the `instance_launch_options` input was added to fill the gap in the implementation.